### PR TITLE
Verify against Maven 4.0.0-rc-6

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -27,6 +27,6 @@ jobs:
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v5
     with:
       maven4-enabled: true
-      maven4-version: '4.0.0-rc-4'
+      maven4-version: '4.0.0-rc-6'
       verify-goal: 'verify'
       matrix-exclude: '[ {"jdk": "25"} ]'


### PR DESCRIPTION
Move the Maven 4 version used by the Verify workflow to 4.0.0-rc-6, the current RC.

Verified: green on the fork before opening.
