### PR TITLE
Inherit the palantirJavaFormat version from the parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,6 @@
     <mavenVersion>3.6.3</mavenVersion>
     <javaVersion>8</javaVersion>
     <project.build.outputTimestamp>2020-04-04T09:03:59Z</project.build.outputTimestamp>
-    <version.palantirJavaFormat>2.81.0</version.palantirJavaFormat>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
The local `version.palantirJavaFormat` property pins **2.81.0**. `org.apache.maven:maven-parent:49` manages **2.93.0**, so the pin had quietly turned into a downgrade holding the formatter back rather than the bump it was when it was added.

This is the safe kind of formatter bump: `mvn spotless:apply` against 2.93.0 leaves **every source file untouched** — the only change in this PR is the deleted pom line, and `spotless:check` passes.

Part of a sweep across the Maven repositories for local pom properties that no longer override anything useful.

Generated-by: Claude Opus 5 (1M context)
