### PR TITLE
Simplify regex in MappingUtils.evaluateFileNameMapping

### DIFF
--- a/src/main/java/org/apache/maven/shared/mapping/MappingUtils.java
+++ b/src/main/java/org/apache/maven/shared/mapping/MappingUtils.java
@@ -87,13 +87,13 @@ public final class MappingUtils {
      */
     public static String evaluateFileNameMapping(String expression, Artifact artifact) throws InterpolationException {
 
-        RegexBasedInterpolator interpolator = new RegexBasedInterpolator("\\@\\{(", ")?([^}]+)\\}@");
+        RegexBasedInterpolator interpolator = new RegexBasedInterpolator("", "\\@\\{([^}]+)\\}@");
         interpolator.addValueSource(new ObjectBasedValueSource(artifact));
         interpolator.addValueSource(new ObjectBasedValueSource(artifact.getArtifactHandler()));
 
         // Support for special expressions, like @{dashClassifier?}@, see MWAR-212
         interpolator.addValueSource(new DashClassifierValueSource(artifact.getClassifier()));
 
-        return interpolator.interpolate(expression, "__artifact");
+        return interpolator.interpolate(expression, (String) null);
     }
 }


### PR DESCRIPTION
## Summary

Remove the unnecessary empty capture group and `__artifact` prefix trick from the `RegexBasedInterpolator` pattern in `MappingUtils.evaluateFileNameMapping`.

## Problem

The previous regex used `startRegex='\\@\\{('` and `endRegex=')?([^}]+)\\}@'` with `thisPrefixPattern='__artifact'`, creating the pattern:

```
\@\{(__artifact)?([^}]+)\}@
```

This contained an unused optional group `(__artifact)?` that served no real purpose -- the `__artifact` string was a dummy prefix intended to be filtered out by the optional group, but since the custom prefix/suffix already delimit `@{...}@` expressions, the prefix filtering is redundant.

## Fix

The new approach uses an empty `startRegex` with the full capture pattern in `endRegex` and passes `null` for `thisPrefixPattern`:

```java
RegexBasedInterpolator interpolator = new RegexBasedInterpolator("", "\\@\\{([^}]+)\\}@");
return interpolator.interpolate(expression, (String) null);
```

This produces the simpler pattern `\@\{([^}]+)\}@` with the key captured directly in group 1.

## Verification

All existing tests pass without modification:

- `completeMapping`
- `noVersionMapping`
- `mappingWithGroupId`
- `mappingWithClassifier`
- `mappingWithNullClassifier`
- `mappingWithOptionalClassifier` (MWAR-212)

Closes #67
