### PR TITLE
Remove duplicate license headers

### DIFF
--- a/src/main/java/org/apache/maven/shared/mapping/DashClassifierValueSource.java
+++ b/src/main/java/org/apache/maven/shared/mapping/DashClassifierValueSource.java
@@ -18,25 +18,6 @@
  */
 package org.apache.maven.shared.mapping;
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 import java.util.Properties;
 
 import org.codehaus.plexus.interpolation.PropertiesBasedValueSource;

--- a/src/main/java/org/apache/maven/shared/mapping/MappingUtils.java
+++ b/src/main/java/org/apache/maven/shared/mapping/MappingUtils.java
@@ -18,25 +18,6 @@
  */
 package org.apache.maven.shared.mapping;
 
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 import org.apache.maven.artifact.Artifact;
 import org.codehaus.plexus.interpolation.InterpolationException;
 import org.codehaus.plexus.interpolation.ObjectBasedValueSource;


### PR DESCRIPTION
Both `MappingUtils.java` and `DashClassifierValueSource.java` contained the full Apache License 2.0 header block twice -- once before the `package` declaration and again after it. This removes the second (duplicate) occurrence from each file.

No code or tests were changed. All existing tests pass.

Closes #66
