### PR TITLE
Add tests for @{baseVersion}@ and DEFAULT_FILE_NAME_MAPPING constants

### DIFF
--- a/src/test/java/org/apache/maven/shared/mapping/MappingUtilsTest.java
+++ b/src/test/java/org/apache/maven/shared/mapping/MappingUtilsTest.java
@@ -117,4 +117,46 @@ class MappingUtilsTest {
                 "maven-test-lib-1.0-classifier.jar",
                 MappingUtils.evaluateFileNameMapping(mappingWithOptionalClassifier2, jar));
     }
+
+    @Test
+    void baseVersionMapping() throws Exception {
+        Artifact jar = new DefaultArtifact(
+                "org.apache.sample", "maven-test-lib", "1.0", null, "jar", null, new DefaultArtifactHandler("jar"));
+        assertEquals(
+                "maven-test-lib-1.0.jar",
+                MappingUtils.evaluateFileNameMapping("@{artifactId}@-@{baseVersion}@.@{extension}@", jar));
+    }
+
+    @Test
+    void defaultFileNameMapping() throws Exception {
+        Artifact jar = new DefaultArtifact(
+                "org.apache.sample", "maven-test-lib", "1.0", null, "jar", null, new DefaultArtifactHandler("jar"));
+        assertEquals(
+                "maven-test-lib-1.0.jar",
+                MappingUtils.evaluateFileNameMapping(MappingUtils.DEFAULT_FILE_NAME_MAPPING, jar));
+    }
+
+    @Test
+    void defaultFileNameMappingClassifier() throws Exception {
+        Artifact jar = new DefaultArtifact(
+                "org.apache.sample",
+                "maven-test-lib",
+                "1.0",
+                null,
+                "jar",
+                "classifier",
+                new DefaultArtifactHandler("jar"));
+        assertEquals(
+                "maven-test-lib-1.0-classifier.jar",
+                MappingUtils.evaluateFileNameMapping(MappingUtils.DEFAULT_FILE_NAME_MAPPING_CLASSIFIER, jar));
+    }
+
+    @Test
+    void defaultFileNameMappingNullClassifier() throws Exception {
+        Artifact jar = new DefaultArtifact(
+                "org.apache.sample", "maven-test-lib", "1.0", null, "jar", null, new DefaultArtifactHandler("jar"));
+        assertEquals(
+                "maven-test-lib-1.0-.jar",
+                MappingUtils.evaluateFileNameMapping(MappingUtils.DEFAULT_FILE_NAME_MAPPING_CLASSIFIER, jar));
+    }
 }


### PR DESCRIPTION
Both `DEFAULT_FILE_NAME_MAPPING` and `DEFAULT_FILE_NAME_MAPPING_CLASSIFIER` use `@{baseVersion}@`, but no existing test ever exercised this expression or these constants.

Added four tests:

- `baseVersionMapping` -- directly tests `@{baseVersion}@` in a mapping expression
- `defaultFileNameMapping` -- tests the `DEFAULT_FILE_NAME_MAPPING` constant
- `defaultFileNameMappingClassifier` -- tests `DEFAULT_FILE_NAME_MAPPING_CLASSIFIER` with a non-null classifier
- `defaultFileNameMappingNullClassifier` -- tests `DEFAULT_FILE_NAME_MAPPING_CLASSIFIER` with a null classifier

All 10 tests pass.

Closes #64
