### PR TITLE
Add null check for artifact parameter in evaluateFileNameMapping

### DIFF
--- a/src/main/java/org/apache/maven/shared/mapping/MappingUtils.java
+++ b/src/main/java/org/apache/maven/shared/mapping/MappingUtils.java
@@ -86,6 +86,9 @@ public final class MappingUtils {
      * @return expression the expression to be evaluated
      */
     public static String evaluateFileNameMapping(String expression, Artifact artifact) throws InterpolationException {
+        if (artifact == null) {
+            throw new IllegalArgumentException("artifact cannot be null");
+        }
 
         RegexBasedInterpolator interpolator = new RegexBasedInterpolator("\\@\\{(", ")?([^}]+)\\}@");
         interpolator.addValueSource(new ObjectBasedValueSource(artifact));

--- a/src/test/java/org/apache/maven/shared/mapping/MappingUtilsTest.java
+++ b/src/test/java/org/apache/maven/shared/mapping/MappingUtilsTest.java
@@ -24,6 +24,7 @@ import org.apache.maven.artifact.handler.DefaultArtifactHandler;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests the mapping of file names.
@@ -116,5 +117,12 @@ class MappingUtilsTest {
         assertEquals(
                 "maven-test-lib-1.0-classifier.jar",
                 MappingUtils.evaluateFileNameMapping(mappingWithOptionalClassifier2, jar));
+    }
+
+    @Test
+    void mappingWithNullArtifact() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> MappingUtils.evaluateFileNameMapping("@{artifactId}@.@{extension}@", null));
     }
 }


### PR DESCRIPTION
## Problem

`MappingUtils.evaluateFileNameMapping(String, Artifact)` throws an opaque `NullPointerException` when `artifact` is null, making it difficult for callers to diagnose the issue:

```
NullPointerException: Cannot invoke "Artifact.getArtifactHandler()" because "artifact" is null
```

## Fix

Added an explicit null check at the start of `evaluateFileNameMapping` that throws `IllegalArgumentException` with a clear message:

```java
if (artifact == null) {
    throw new IllegalArgumentException("artifact cannot be null");
}
```

## Test

Added `mappingWithNullArtifact` which verifies that `IllegalArgumentException` is thrown when null is passed for the artifact parameter.

All 7 tests pass.

Closes #62
